### PR TITLE
Context save and restore

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -12,7 +12,7 @@ fn main() {
         unicorn::arch_supported(unicorn::Arch::MIPS)
     );
 
-    let mut emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to create emulator");
+    let emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to create emulator");
 
     let page_size = emu.query(unicorn::Query::PAGE_SIZE)
         .expect("failed to query page size");

--- a/libunicorn-sys/src/lib.rs
+++ b/libunicorn-sys/src/lib.rs
@@ -6,7 +6,7 @@ pub mod unicorn_const;
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
-use unicorn_const::{Arch, MemRegion, Mode, Error, HookType, Query};
+use unicorn_const::{Arch, MemRegion, Mode, Error, HookType, Query, Context};
 
 #[allow(non_camel_case_types)]
 pub type uc_handle = libc::size_t;
@@ -70,6 +70,12 @@ extern "C" {
                        -> Error;
     pub fn uc_hook_del(engine: uc_handle, hook: uc_hook) -> Error;
     pub fn uc_query(engine: uc_handle, query_type: Query, result: *mut libc::size_t) -> Error;
+    
+    pub fn uc_context_alloc(engine: uc_handle, context: *mut *mut Context) -> Error;
+    pub fn uc_context_save(engine: uc_handle, context: *mut Context) -> Error;
+    pub fn uc_context_restore(engine: uc_handle, context: *const Context) -> Error;
+
+    
 }
 
 

--- a/libunicorn-sys/src/unicorn_const.rs
+++ b/libunicorn-sys/src/unicorn_const.rs
@@ -171,7 +171,4 @@ pub enum Query {
 /// An "opaque" block of memory where the context of a
 /// Unicorn instance can be stored, for efficient rollback, etc.
 
-pub struct Context(*mut libc::c_void);
-impl Context {
-    pub unsafe fn new() -> Self { Context(unsafe{mem::uninitialized()}) }
-}
+pub enum Context {}

--- a/libunicorn-sys/src/unicorn_const.rs
+++ b/libunicorn-sys/src/unicorn_const.rs
@@ -1,4 +1,7 @@
 #![allow(non_camel_case_types)]
+extern crate libc;
+
+use std::mem;
 
 pub const SECOND_SCALE: u64 = 1000000;
 pub const MILISECOND_SCALE: u64 = 1000;
@@ -163,4 +166,12 @@ pub enum Query {
     MODE = 1,
     /// The page size used by the emulator
     PAGE_SIZE,
+}
+
+/// An "opaque" block of memory where the context of a
+/// Unicorn instance can be stored, for efficient rollback, etc.
+
+pub struct Context(*mut libc::c_void);
+impl Context {
+    pub unsafe fn new() -> Self { Context(unsafe{mem::uninitialized()}) }
 }

--- a/src/arm_const.rs
+++ b/src/arm_const.rs
@@ -117,11 +117,3 @@ pub enum RegisterARM {
     S31 = 110,
 }
 
-/* TODO
-#[repr(C)]
-#[derive(PartialEq, Debug, Clone, Copy)]
-pub enum InsnARM {
-
-
-}
-*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1126,7 +1126,6 @@ impl Unicorn {
     /// Save and return the current CPU Context, which can
     /// later be passed to restore_context to roll back changes
     /// in the emulator.
-    /// UNSTABLE
     pub unsafe fn context_save(&self) -> Result<*const Context, Error> {
         let context: Context = mem::uninitialized();
         let p_context: *mut Context = unsafe { 
@@ -1148,7 +1147,11 @@ impl Unicorn {
         Ok(p_context)
     }
 
-    pub unsafe fn context_restore(&mut self, context: *const Context) -> Result<(), Error> {
+    /// Restore a saved context. This can be used to roll back changes in
+    /// a CPU's register state (but not memory), or to duplicate a register
+    /// state across multiple CPUs.
+    pub unsafe fn context_restore(&mut self, context: *const Context) 
+        -> Result<(), Error> {
         let p_context: *const Context = unsafe {
             mem::transmute(&*context)
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,21 +109,21 @@ pub trait Cpu {
     }
 
     /// Write an unsigned value register.
-    fn reg_write(&mut self, reg: Self::Reg, value: u64) -> Result<(), Error> {
-        self.mut_emu().reg_write(reg.to_i32(), value)
+    fn reg_write(&self, reg: Self::Reg, value: u64) -> Result<(), Error> {
+        self.emu().reg_write(reg.to_i32(), value)
     }
 
     /// Write a signed 32-bit value to a register.
-    fn reg_write_i32(&mut self, reg: Self::Reg, value: i32) -> Result<(), Error> {
-        self.mut_emu().reg_write_i32(reg.to_i32(), value)
+    fn reg_write_i32(&self, reg: Self::Reg, value: i32) -> Result<(), Error> {
+        self.emu().reg_write_i32(reg.to_i32(), value)
     }
 
     /// Map a memory region in the emulator at the specified address.
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
-    fn mem_map(&mut self, address: u64, size: libc::size_t, perms: Protection) -> Result<(), Error> {
-        self.mut_emu().mem_map(address, size, perms)
+    fn mem_map(&self, address: u64, size: libc::size_t, perms: Protection) -> Result<(), Error> {
+        self.emu().mem_map(address, size, perms)
     }
 
     /// Map an existing memory region in the emulator at the specified address.
@@ -138,26 +138,26 @@ pub trait Cpu {
     ///
     /// `ptr` is a pointer to the provided memory region that will be used by the emulator.
     unsafe fn mem_map_ptr<T>(
-        &mut self,
+        &self,
         address: u64,
         size: libc::size_t,
         perms: Protection,
         ptr: *mut T,
     ) -> Result<(), Error> {
-        self.mut_emu().mem_map_ptr(address, size, perms, ptr)
+        self.emu().mem_map_ptr(address, size, perms, ptr)
     }
 
     /// Unmap a memory region.
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
-    fn mem_unmap(&mut self, address: u64, size: libc::size_t) -> Result<(), Error> {
-        self.mut_emu().mem_unmap(address, size)
+    fn mem_unmap(&self, address: u64, size: libc::size_t) -> Result<(), Error> {
+        self.emu().mem_unmap(address, size)
     }
 
     /// Write a range of bytes to memory at the specified address.
-    fn mem_write(&mut self, address: u64, bytes: &[u8]) -> Result<(), Error> {
-        self.mut_emu().mem_write(address, bytes)
+    fn mem_write(&self, address: u64, bytes: &[u8]) -> Result<(), Error> {
+        self.emu().mem_write(address, bytes)
     }
 
     /// Read a range of bytes from memory at the specified address.
@@ -169,8 +169,8 @@ pub trait Cpu {
     ///
     /// `address` must be aligned to 4kb or this will return `Error::ARG`.
     /// `size` must be a multiple of 4kb or this will return `Error::ARG`.
-    fn mem_protect(&mut self, address: u64, size: usize, perms: Protection) -> Result<(), Error> {
-        self.mut_emu().mem_protect(address, size, perms)
+    fn mem_protect(&self, address: u64, size: usize, perms: Protection) -> Result<(), Error> {
+        self.emu().mem_protect(address, size, perms)
     }
 
     /// Returns a vector with the memory regions that are mapped in the emulator.
@@ -184,16 +184,16 @@ pub trait Cpu {
     /// is hit. `timeout` specifies a duration in microseconds after which the emulation is
     /// stopped (infinite execution if set to 0). `count` is the maximum number of instructions
     /// to emulate (emulate all the available instructions if set to 0).
-    fn emu_start(&mut self, begin: u64, until: u64, timeout: u64, count: usize) -> Result<(), Error> {
-        self.mut_emu().emu_start(begin, until, timeout, count)
+    fn emu_start(&self, begin: u64, until: u64, timeout: u64, count: usize) -> Result<(), Error> {
+        self.emu().emu_start(begin, until, timeout, count)
     }
 
     /// Stop the emulation.
     ///
     /// This is usually called from callback function in hooks.
     /// NOTE: For now, this will stop the execution only after the current block.
-    fn emu_stop(&mut self) -> Result<(), Error> {
-        self.mut_emu().emu_stop()
+    fn emu_stop(&self) -> Result<(), Error> {
+        self.emu().emu_stop()
     }
 
     /// Add a code hook.
@@ -292,8 +292,8 @@ pub trait Cpu {
         self.emu().context_save()
     }
 
-    unsafe fn context_restore(&mut self, context: *const Context) -> Result<(), Error> {
-        self.mut_emu().context_restore(context)
+    unsafe fn context_restore(&self, context: *const Context) -> Result<(), Error> {
+        self.emu().context_restore(context)
     }
 }
 
@@ -1150,7 +1150,7 @@ impl Unicorn {
     /// Restore a saved context. This can be used to roll back changes in
     /// a CPU's register state (but not memory), or to duplicate a register
     /// state across multiple CPUs.
-    pub unsafe fn context_restore(&mut self, context: *const Context) 
+    pub unsafe fn context_restore(&self, context: *const Context) 
         -> Result<(), Error> {
         let p_context: *const Context = unsafe {
             mem::transmute(&*context)

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -462,3 +462,183 @@ fn mem_map_ptr() {
     assert_eq!(emu.reg_read(unicorn::RegisterX86::EDX), Ok(49));
     assert_eq!(emu.mem_unmap(0x1000, 0x4000), Ok(()));
 }
+
+#[test]
+fn x86_context_save_and_restore () {
+
+    for mode in vec![ /* unicorn::Mode::MODE_32,  */
+                      unicorn::Mode::MODE_64 ] {
+    
+        let x86_code: Vec<u8> = vec![
+            0x48, 0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x05
+        ];
+        let mut emu = CpuX86::new(mode).expect("failed to instantiate emulator");
+        assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
+        assert_eq!(emu.mem_write(0x1000, &x86_code), Ok(()));
+        let _ = emu.emu_start(0x1000,
+                              (0x1000 + x86_code.len()) as u64,
+                              10 * unicorn::SECOND_SCALE,
+                              1000);
+
+        /* now, save the context... */
+        let context = unsafe { emu.context_save() };
+        let context = context.unwrap();
+        
+        /* and create a new emulator, into which we will "restore" that context */
+        let mut emu2 = CpuX86::new(mode)
+            .expect("failed to instantiate emu2");
+        assert_eq!(unsafe { emu2.context_restore(context) }, Ok(()));
+        for register in X86_REGISTERS.iter() {
+            println!("Testing register {:?}", register);
+            assert_eq!(emu2.reg_read(*register), emu.reg_read(*register));
+        }
+    }
+}
+
+pub static X86_REGISTERS: [unicorn::RegisterX86; 145] = [
+    unicorn::RegisterX86::AH,
+    unicorn::RegisterX86::AL,
+    unicorn::RegisterX86::AX,
+    unicorn::RegisterX86::BH,
+    unicorn::RegisterX86::BL,
+    unicorn::RegisterX86::BP,
+    unicorn::RegisterX86::BPL,
+    unicorn::RegisterX86::BX,
+    unicorn::RegisterX86::CH,
+    unicorn::RegisterX86::CL,
+    unicorn::RegisterX86::CS,
+    unicorn::RegisterX86::CX,
+    unicorn::RegisterX86::DH,
+    unicorn::RegisterX86::DI,
+    unicorn::RegisterX86::DIL,
+    unicorn::RegisterX86::DL,
+    unicorn::RegisterX86::DS,
+    unicorn::RegisterX86::DX,
+    unicorn::RegisterX86::EAX,
+    unicorn::RegisterX86::EBP,
+    unicorn::RegisterX86::EBX,
+    unicorn::RegisterX86::ECX,
+    unicorn::RegisterX86::EDI,
+    unicorn::RegisterX86::EDX,
+    unicorn::RegisterX86::EFLAGS,
+    unicorn::RegisterX86::EIP,
+    unicorn::RegisterX86::EIZ,
+    unicorn::RegisterX86::ES,
+    unicorn::RegisterX86::ESI,
+    unicorn::RegisterX86::ESP,
+    unicorn::RegisterX86::FPSW,
+    unicorn::RegisterX86::FS,
+    unicorn::RegisterX86::GS,
+    unicorn::RegisterX86::IP,
+    unicorn::RegisterX86::RAX,
+    unicorn::RegisterX86::RBP,
+    unicorn::RegisterX86::RBX,
+    unicorn::RegisterX86::RCX,
+    unicorn::RegisterX86::RDI,
+    unicorn::RegisterX86::RDX,
+    unicorn::RegisterX86::RIP,
+    unicorn::RegisterX86::RIZ,
+    unicorn::RegisterX86::RSI,
+    unicorn::RegisterX86::RSP,
+    unicorn::RegisterX86::SI,
+    unicorn::RegisterX86::SIL,
+    unicorn::RegisterX86::SP,
+    unicorn::RegisterX86::SPL,
+    unicorn::RegisterX86::SS,
+    unicorn::RegisterX86::CR0,
+    unicorn::RegisterX86::CR1,
+    unicorn::RegisterX86::CR2,
+    unicorn::RegisterX86::CR3,
+    unicorn::RegisterX86::CR4,
+    unicorn::RegisterX86::CR5,
+    unicorn::RegisterX86::CR6,
+    unicorn::RegisterX86::CR7,
+    unicorn::RegisterX86::CR8,
+    unicorn::RegisterX86::CR9,
+    unicorn::RegisterX86::CR10,
+    unicorn::RegisterX86::CR11,
+    unicorn::RegisterX86::CR12,
+    unicorn::RegisterX86::CR13,
+    unicorn::RegisterX86::CR14,
+    unicorn::RegisterX86::CR15,
+    unicorn::RegisterX86::DR0,
+    unicorn::RegisterX86::DR1,
+    unicorn::RegisterX86::DR2,
+    unicorn::RegisterX86::DR3,
+    unicorn::RegisterX86::DR4,
+    unicorn::RegisterX86::DR5,
+    unicorn::RegisterX86::DR6,
+    unicorn::RegisterX86::DR7,
+    unicorn::RegisterX86::DR8,
+    unicorn::RegisterX86::DR9,
+    unicorn::RegisterX86::DR10,
+    unicorn::RegisterX86::DR11,
+    unicorn::RegisterX86::DR12,
+    unicorn::RegisterX86::DR13,
+    unicorn::RegisterX86::DR14,
+    unicorn::RegisterX86::DR15,
+    unicorn::RegisterX86::FP0,
+    unicorn::RegisterX86::FP1,
+    unicorn::RegisterX86::FP2,
+    unicorn::RegisterX86::FP3,
+    unicorn::RegisterX86::FP4,
+    unicorn::RegisterX86::FP5,
+    unicorn::RegisterX86::FP6,
+    unicorn::RegisterX86::FP7,
+    unicorn::RegisterX86::K0,
+    unicorn::RegisterX86::K1,
+    unicorn::RegisterX86::K2,
+    unicorn::RegisterX86::K3,
+    unicorn::RegisterX86::K4,
+    unicorn::RegisterX86::K5,
+    unicorn::RegisterX86::K6,
+    unicorn::RegisterX86::K7,
+    unicorn::RegisterX86::MM0,
+    unicorn::RegisterX86::MM1,
+    unicorn::RegisterX86::MM2,
+    unicorn::RegisterX86::MM3,
+    unicorn::RegisterX86::MM4,
+    unicorn::RegisterX86::MM5,
+    unicorn::RegisterX86::MM6,
+    unicorn::RegisterX86::MM7,
+    unicorn::RegisterX86::R8,
+    unicorn::RegisterX86::R9,
+    unicorn::RegisterX86::R10,
+    unicorn::RegisterX86::R11,
+    unicorn::RegisterX86::R12,
+    unicorn::RegisterX86::R13,
+    unicorn::RegisterX86::R14,
+    unicorn::RegisterX86::R15,
+    unicorn::RegisterX86::ST0,
+    unicorn::RegisterX86::ST1,
+    unicorn::RegisterX86::ST2,
+    unicorn::RegisterX86::ST3,
+    unicorn::RegisterX86::ST4,
+    unicorn::RegisterX86::ST5,
+    unicorn::RegisterX86::ST6,
+    unicorn::RegisterX86::ST7,
+    unicorn::RegisterX86::R8B,
+    unicorn::RegisterX86::R9B,
+    unicorn::RegisterX86::R10B,
+    unicorn::RegisterX86::R11B,
+    unicorn::RegisterX86::R12B,
+    unicorn::RegisterX86::R13B,
+    unicorn::RegisterX86::R14B,
+    unicorn::RegisterX86::R15B,
+    unicorn::RegisterX86::R8D,
+    unicorn::RegisterX86::R9D,
+    unicorn::RegisterX86::R10D,
+    unicorn::RegisterX86::R11D,
+    unicorn::RegisterX86::R12D,
+    unicorn::RegisterX86::R13D,
+    unicorn::RegisterX86::R14D,
+    unicorn::RegisterX86::R15D,
+    unicorn::RegisterX86::R8W,
+    unicorn::RegisterX86::R9W,
+    unicorn::RegisterX86::R10W,
+    unicorn::RegisterX86::R11W,
+    unicorn::RegisterX86::R12W,
+    unicorn::RegisterX86::R13W,
+    unicorn::RegisterX86::R14W,
+    unicorn::RegisterX86::R15W,
+];

--- a/tests/unicorn.rs
+++ b/tests/unicorn.rs
@@ -8,7 +8,7 @@ use unicorn::{Cpu, CpuARM, CpuMIPS, CpuX86};
 fn emulate_x86() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(emu.reg_write(unicorn::RegisterX86::EAX, 123), Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterX86::EAX), Ok(123));
 
@@ -45,7 +45,7 @@ fn emulate_x86() {
 fn emulate_x86_negative_values() {
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
 
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &x86_code32), Ok(()));
@@ -86,7 +86,7 @@ fn callback_lifetime_init() -> unicorn::CpuX86 {
 #[test]
 fn test_callback_lifetime() {
     // Regression test for https://github.com/ekse/unicorn-rs/issues/13
-    let mut emu = callback_lifetime_init();
+    let emu = callback_lifetime_init();
     println!("Foobar");
     assert_eq!(
         emu.emu_start(0x1000, 0x1002, 10 * unicorn::SECOND_SCALE, 1000),
@@ -320,7 +320,7 @@ fn x86_insn_sys_callback() {
 fn emulate_arm() {
     let arm_code32: Vec<u8> = vec![0x83, 0xb0]; // sub    sp, #0xc
 
-    let mut emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to instantiate emulator");
+    let emu = CpuARM::new(unicorn::Mode::THUMB).expect("failed to instantiate emulator");
     assert_eq!(emu.reg_write(unicorn::RegisterARM::R1, 123), Ok(()));
     assert_eq!(emu.reg_read(unicorn::RegisterARM::R1), Ok(123));
 
@@ -359,7 +359,7 @@ fn emulate_arm() {
 fn emulate_mips() {
     let mips_code32 = vec![0x56, 0x34, 0x21, 0x34]; // ori $at, $at, 0x3456;
 
-    let mut emu = CpuMIPS::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuMIPS::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_write(0x1000, &mips_code32), Ok(()));
     assert_eq!(
@@ -381,7 +381,7 @@ fn emulate_mips() {
 
 #[test]
 fn mem_unmapping() {
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
     assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
     assert_eq!(emu.mem_unmap(0x1000, 0x4000), Ok(()));
 }
@@ -392,7 +392,7 @@ fn mem_map_ptr() {
     let mut mem: [u8; 4000] = [0; 4000];
     let x86_code32: Vec<u8> = vec![0x41, 0x4a]; // INC ecx; DEC edx
 
-    let mut emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
+    let emu = CpuX86::new(unicorn::Mode::MODE_32).expect("failed to instantiate emulator");
 
     // Attempt to write to memory before mapping it.
     assert_eq!(
@@ -472,7 +472,7 @@ fn x86_context_save_and_restore () {
         let x86_code: Vec<u8> = vec![
             0x48, 0xB8, 0xEF, 0xBE, 0xAD, 0xDE, 0x00, 0x00, 0x00, 0x00, 0x0F, 0x05
         ];
-        let mut emu = CpuX86::new(mode).expect("failed to instantiate emulator");
+        let emu = CpuX86::new(mode).expect("failed to instantiate emulator");
         assert_eq!(emu.mem_map(0x1000, 0x4000, unicorn::PROT_ALL), Ok(()));
         assert_eq!(emu.mem_write(0x1000, &x86_code), Ok(()));
         let _ = emu.emu_start(0x1000,
@@ -485,7 +485,7 @@ fn x86_context_save_and_restore () {
         let context = context.unwrap();
         
         /* and create a new emulator, into which we will "restore" that context */
-        let mut emu2 = CpuX86::new(mode)
+        let emu2 = CpuX86::new(mode)
             .expect("failed to instantiate emu2");
         assert_eq!(unsafe { emu2.context_restore(context) }, Ok(()));
         for register in X86_REGISTERS.iter() {


### PR DESCRIPTION
Enables context_save and context_restore (unsafe) methods on the emulator. 